### PR TITLE
Allow for anonymous IEnumerables.

### DIFF
--- a/src/TypeScriptDefinitionsGenerator/Program.cs
+++ b/src/TypeScriptDefinitionsGenerator/Program.cs
@@ -108,7 +108,7 @@ namespace TypeScriptDefinitionsGenerator
                         .Where(m => m.DeclaringType == c));
                 ProcessMethods(actions, generator);
 
-                var signalrHubs = assembly.GetTypes().Where(t => t.GetInterfaces().ToList().Exists(i => i.FullName.Contains(SignalRGenerator.IHUB_TYPE)));
+                var signalrHubs = assembly.GetTypes().Where(t => t.GetInterfaces().ToList().Exists(i => i.FullName != null && i.FullName.Contains(SignalRGenerator.IHUB_TYPE)));
                 var methods = signalrHubs
                     .SelectMany(h => h.GetMethods()
                         .Where(m => m.IsPublic)


### PR DESCRIPTION
Hi slovely - I've discovered a case where (for some as yet unknown reason) an IEnumerable interface can come through without a full name.  This is just a check to see if the name is set before filtering on it. 

Cheers
neilbu :)